### PR TITLE
Replace dependency execSync module with sync-exec

### DIFF
--- a/examples/driver-isloaded.js
+++ b/examples/driver-isloaded.js
@@ -2,7 +2,7 @@
 
 var Driver = require('../lib/driver'),
     exec = require('child_process').exec,
-    execSync = require('execSync').run,
+    execSync = require('sync-exec').run,
     fs = require('fs'),
 
     driver = new Driver(fs, exec, execSync, '/sys/bus/w1'),

--- a/initialize.js
+++ b/initialize.js
@@ -9,7 +9,7 @@ module.exports = function () {
 		// External dependencies
 		.object('fs', require('fs'))
 		.object('exec', require('child_process').exec)
-		.object('execSync', require('execSync').run)
+		.object('execSync', require('sync-exec').run)
 
 		// Configurations
 		.object('driverBasePath', '/sys/bus/w1')

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -4,7 +4,7 @@ var path = require('path');
 
 function checkErrors(err, deviceId) {
 
-    if (err.code === 'ENOENT' && err.errno === 34) {
+    if (err.code === 'ENOENT') {
         err = new Error('Could not read device content. Device \'' + deviceId + '\' not found');
     }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "async": "~0.2.9",
     "sandal": "~1.0.1",
-    "execSync": "~1.0.1-pre"
+    "sync-exec": "~0.5"
   },
   "devDependencies": {
     "tap": "~0.4.6",

--- a/test/unit/ds18x20-isdriverloaded-test.js
+++ b/test/unit/ds18x20-isdriverloaded-test.js
@@ -5,7 +5,7 @@ var test = require('tap').test,
     fs = require('fs'),
     path = require('path'),
     exec = require('child_process').exec,
-    execSync = require('execSync'),
+    execSync = require('sync-exec'),
 
 	Driver = require('../../lib/driver'),
 	Ds18x20 = require('../../lib/ds18x20');


### PR DESCRIPTION
ds18x20 cannot be currently installed with node.js 0.12 as
execSync module doesn't work with nodejs 0.12 and the author of
that module cannot make an update to the module to fix that. [1]

We replace execSync with sync-exec [2] which is "an fs.execSync
replacement until you get it natively from node 0.12+".

Also, the error number for ENOENT in nodejs 0.12 is -2 instead of
34 which is was previously. Therefore we remove the check
"errno == 34" (it should be anyways enough to test that
"code == ENOENT").

This fixes issue #2.

[1] https://github.com/mgutz/execSync/issues/38
[2] https://www.npmjs.com/package/sync-exec